### PR TITLE
Add full output support in diptest

### DIFF
--- a/.github/workflows/openmp.yml
+++ b/.github/workflows/openmp.yml
@@ -1,0 +1,78 @@
+name: OpenMP Build
+
+on: 
+  pull_request:
+    branches:
+      - stable
+  schedule:
+    - cron: '0 23 * * 1'
+  push:
+    branches:
+      - stable
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          cancel_others: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+  build:
+    name: OpenMP
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: 
+        - {
+            name: "Ubuntu (GCC-11)",
+            build_type: "Release",
+            cc: "gcc-11",
+            cxx: "g++-11",
+            generators: "Ninja",
+            target: "all"
+          }
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Install python pacakges
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install numpy pytest
+          
+      - name: Install
+        run: |
+          CMAKE_ARGS="-DDIPTEST_ENABLE_OPENMP=ON" pip install . -v
+
+      - name: Test
+        run: |
+          cd tests
+          python -m pytest test_diptest.py

--- a/diptest/diptest.py
+++ b/diptest/diptest.py
@@ -178,8 +178,8 @@ def diptest(
         func = None
         if n_threads > 1:
             if _diptest._has_openmp_support:
-                kwargs['n_threads'] = threads
-                func = diptest.diptest_pval_mt
+                kwargs["n_threads"] = n_threads
+                func = _diptest.diptest_pval_mt
             else:
                 warnings.warn(
                     "Extension was compiled without parallelisation "

--- a/diptest/diptest.py
+++ b/diptest/diptest.py
@@ -1,10 +1,10 @@
 import warnings
-import psutil
 
 import numpy as np
+import psutil
 
-from diptest.lib import _diptest
 from diptest.consts import Consts
+from diptest.lib import _diptest
 
 _N_CORES = psutil.cpu_count(logical=False)
 _N_CORES_MIN1 = _N_CORES - 1
@@ -62,23 +62,20 @@ def dipstat(x, full_output=False, allow_zero=True, sort_x=True, debug=0):
     if sort_x:
         x = np.sort(x)
     elif not isinstance(x, np.ndarray):
-        x = np.asarray(x, order='C')
+        x = np.asarray(x, order="C")
     elif not (x.flags.c_contiguous or x.flags.c_contiguous):
-        x = np.copy(x, order='C')
+        x = np.copy(x, order="C")
 
-    if ((x.ndim > 1) and not (
-            (x.shape[1] == 1) or (x.shape[0]== 1)
-        )
-    ):
-        raise TypeError('x should be one-dimensional')
+    if (x.ndim > 1) and not ((x.shape[1] == 1) or (x.shape[0] == 1)):
+        raise TypeError("x should be one-dimensional")
 
     if full_output:
         res = _diptest.diptest_full(x, allow_zero, debug)
-        dip = res.pop('dip')
-        _gcm = res.pop('_gcm')
-        res['gcm'] = _gcm[:res.pop('_lh_2')]
-        _lcm = res.pop('_lcm')
-        res['lcm'] = _lcm[:res.pop('_lh_3')]
+        dip = res.pop("dip")
+        _gcm = res.pop("_gcm")
+        res["gcm"] = _gcm[: res.pop("_lh_2")]
+        _lcm = res.pop("_lcm")
+        res["lcm"] = _lcm[: res.pop("_lh_3")]
         return float(dip), res
     return float(_diptest.diptest(x, allow_zero, debug))
 
@@ -162,20 +159,20 @@ def diptest(
     dip = r if not full_output else r[0]
 
     if n <= 3:
-        warnings.warn('Dip test is not valid for n <= 3')
+        warnings.warn("Dip test is not valid for n <= 3")
         return (dip, 1.0) if not full_output else (dip, 1.0, r[1])
 
     if boot_pval:
         n_threads = n_threads or _DEFAULT_N_THREADS
         if n_threads == -1:
             n_threads = _N_CORES
-        
+
         kwargs = {
-            'dipstat': dip,
-            'n': n,
-            'n_boot': n_boot,
-            'allow_zero': allow_zero,
-            'seed': seed or 0,
+            "dipstat": dip,
+            "n": n,
+            "n_boot": n_boot,
+            "allow_zero": allow_zero,
+            "seed": seed or 0,
         }
 
         func = None
@@ -185,17 +182,17 @@ def diptest(
                 func = diptest.diptest_pval_mt
             else:
                 warnings.warn(
-                    'Extension was compiled without parallelisation '
-                    'support, ignoring ``n_threads``'
+                    "Extension was compiled without parallelisation "
+                    "support, ignoring ``n_threads``"
                 )
 
         if func is None:
             if stream > Consts._UINT64_T_MAX:
-                raise ValueError('`stream` must fit in a uint64_t.')
+                raise ValueError("`stream` must fit in a uint64_t.")
             else:
-                kwargs['stream'] = stream
+                kwargs["stream"] = stream
                 func = _diptest.diptest_pval
-        
+
         pval = func(**kwargs)
     else:
         pval = Consts.compute_pval_interpolation(n, dip)

--- a/tests/test_diptest.py
+++ b/tests/test_diptest.py
@@ -223,3 +223,14 @@ if _has_openmp_support:
             )
             assert np.isclose(dip, _TEST_SAMPLE_DIP)
             assert abs(_TEST_SAMPLE_PVAL - pv) < 5e3
+
+
+def test_diptest_full_output():
+    """Test diptest.diptest with full output."""
+    dip, pval, res = dt.diptest(_TEST_SAMPLE, full_output=True)
+    assert np.isclose(dip, _TEST_SAMPLE_DIP)
+    assert np.isclose(pval, _TEST_SAMPLE_TABLE_PVAL)
+    exp_keys = {'lo', 'hi', 'xl', 'xu', 'gcm', 'lcm'}
+    obs_keys = set(res.keys())
+    assert len(obs_keys - exp_keys) == 0
+    assert len(exp_keys - obs_keys) == 0

--- a/tests/test_diptest.py
+++ b/tests/test_diptest.py
@@ -1,14 +1,15 @@
+import multiprocessing
 import os
 import warnings
-import pytest
+
 import numpy as np
-import multiprocessing
+import pytest
 
 import diptest as dt
 from diptest.lib._diptest import _has_openmp_support
 
 _cdir = os.path.dirname(os.path.realpath(__file__))
-_TEST_SAMPLE = np.load(os.path.join(_cdir, 'test_sample.npy'))
+_TEST_SAMPLE = np.load(os.path.join(_cdir, "test_sample.npy"))
 _TEST_SAMPLE_DIP = 0.0159638598499375
 _TEST_SAMPLE_PVAL = 0.083635
 _TEST_SAMPLE_TABLE_PVAL = 0.0867741514531395
@@ -92,30 +93,18 @@ def test_dipstat_sort_x():
 def test_dipstat_allow_zero():
     """Test diptest.dipstat behaviour for allow_zero parameter."""
     sample = np.ones(100)
-    assert not np.isclose(
-        dt.dipstat(sample, allow_zero=False),
-        0.0
-    )
-    assert np.isclose(
-        dt.dipstat(sample, allow_zero=True),
-        0.0
-    )
+    assert not np.isclose(dt.dipstat(sample, allow_zero=False), 0.0)
+    assert np.isclose(dt.dipstat(sample, allow_zero=True), 0.0)
     sample = _generator(2)
-    assert not np.isclose(
-        dt.dipstat(sample, allow_zero=False),
-        0.0
-    )
-    assert np.isclose(
-        dt.dipstat(sample, allow_zero=True),
-        0.0
-    )
+    assert not np.isclose(dt.dipstat(sample, allow_zero=False), 0.0)
+    assert np.isclose(dt.dipstat(sample, allow_zero=True), 0.0)
 
 
 def test_dipstat_full_output():
     """Test diptest.dipstat with full output."""
     sample = _generator(100)
     dip, res = dt.dipstat(sample, full_output=True)
-    exp_keys = {'lo', 'hi', 'xl', 'xu', 'gcm', 'lcm'}
+    exp_keys = {"lo", "hi", "xl", "xu", "gcm", "lcm"}
     obs_keys = set(res.keys())
     assert len(obs_keys - exp_keys) == 0
     assert len(exp_keys - obs_keys) == 0
@@ -127,8 +116,8 @@ def test_dipstat_non_contiguous():
     """Test diptest.dipstat with non contiguous arrays."""
     sample = _generator(20)
     sample.sort()
-    farr = sample.copy(order='F')
-    carr = sample.copy(order='C')
+    farr = sample.copy(order="F")
+    carr = sample.copy(order="C")
 
     dip = dt.dipstat(farr, sort_x=False)
     assert not np.isnan(dip)
@@ -167,7 +156,7 @@ def test_dipstat_2d():
 
 def test_diptest_default():
     """Test diptest.diptest with default settings."""
-    with np.errstate(all='raise'):
+    with np.errstate(all="raise"):
         dip, pval = dt.diptest(_TEST_SAMPLE)
     assert np.isclose(dip, _TEST_SAMPLE_DIP)
     assert np.isclose(pval, _TEST_SAMPLE_TABLE_PVAL)
@@ -187,39 +176,32 @@ def test_diptest_warning():
 
 def test_diptest_smallest_table_value():
     """Test diptest.diptest with default settings."""
-    with np.errstate(all='raise'):
+    with np.errstate(all="raise"):
         _ = dt.diptest(_generator(4))
 
 
 def test_diptest_larget_table_value():
     """Test diptest.diptest with default settings."""
-    with np.errstate(all='raise'):
+    with np.errstate(all="raise"):
         _ = dt.diptest(_generator(72000))
 
 
 def test_diptest_bootstrap():
     """Test diptest.diptest with bootstrap pvalue"""
     dip, pv = dt.diptest(
-        _TEST_SAMPLE,
-        boot_pval=True,
-        n_boot=10000,
-        n_threads=1,
-        seed=42
+        _TEST_SAMPLE, boot_pval=True, n_boot=10000, n_threads=1, seed=42
     )
     assert np.isclose(dip, _TEST_SAMPLE_DIP)
     assert np.isclose(pv, _TEST_SAMPLE_PVAL, rtol=5e-4)
 
 
 if _has_openmp_support:
+
     def test_diptest_bootstrap_mt():
         cores = multiprocessing.cpu_count() - 1
         if _has_openmp_support and cores > 1:
             dip, pv = dt.diptest(
-                _TEST_SAMPLE,
-                boot_pval=True,
-                n_boot=10000,
-                n_threads=cores,
-                seed=42
+                _TEST_SAMPLE, boot_pval=True, n_boot=10000, n_threads=cores, seed=42
             )
             assert np.isclose(dip, _TEST_SAMPLE_DIP)
             assert abs(_TEST_SAMPLE_PVAL - pv) < 5e3
@@ -230,7 +212,7 @@ def test_diptest_full_output():
     dip, pval, res = dt.diptest(_TEST_SAMPLE, full_output=True)
     assert np.isclose(dip, _TEST_SAMPLE_DIP)
     assert np.isclose(pval, _TEST_SAMPLE_TABLE_PVAL)
-    exp_keys = {'lo', 'hi', 'xl', 'xu', 'gcm', 'lcm'}
+    exp_keys = {"lo", "hi", "xl", "xu", "gcm", "lcm"}
     obs_keys = set(res.keys())
     assert len(obs_keys - exp_keys) == 0
     assert len(exp_keys - obs_keys) == 0


### PR DESCRIPTION
## What?

1. The diptest does not currently support a `full_output` mode.
2. The interpolation code in diptest reduces code readability.

## Why?

There are many works in the literature, e.g., [1], that require both bootstraping and also get the full output since they need access for instance to the mode intervals. The current implementation does not support it, necessitating the need for two distinct calls.

1. Maurus, S., & Plant, C. (2016, August). Skinny-dip: clustering in a sea of noise. In Proceedings of the 22nd ACM SIGKDD international conference on Knowledge discovery and data mining (pp. 1055-1064).

## How?

- The diptest function was extended to support an optional `full_output` input argument (_disabled by default_).
- The interpolation code was refactored and now is part of the Consts class as a `classmethod` .

### Further Architectural Changes

The diptest '_if else_' logic was rewritten to ease readability. The previous version had a lot of similar code segments, i.e., `diptest_pval_mt` and `diptest_pval` with small argument differences.

## Testing?

The implementation has been tested locally in a Darwin platform and all the unittests pass with success.

## Varia

It's been a long time, I hope you are fine @RUrlus :)