### PR TITLE
FIX: Correct the out of index error in interpolation

### DIFF
--- a/diptest/consts.py
+++ b/diptest/consts.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 
@@ -77,7 +79,12 @@ class Consts(object, metaclass=ReadOnlyClass):
         # critical values for the nearest tabulated n (i.e. treat them as
         # 'asymptotic')
         i0 = max(0, i0)
-        i1 = min(cls._CRIT_VALS.shape[0], i1)
+        if i1 > cls._CRIT_VALS.shape[0] - 1:
+            i1 = cls._CRIT_VALS.shape[0] - 1
+            warnings.warn(
+                f"Sample size exceeds the maximum limit of {cls._MAX_SAMPLE_SIZE}. "
+                 "Results may not be accurate with precomputed statistical values."
+            )
 
         # Interpolate on sqrt(n)
         n0, n1 = cls._SAMPLE_SIZE[[i0, i1]]


### PR DESCRIPTION
### What

- Resolves: #31
- Adds a warning message when the interpolation is used when the sample size exceeds our current maximum sample size, i.e., `Consts._MAX_SAMPLE_SIZE`.

### Why

There is a bug introduced in my previous PR where by mistake i set the maximum possible index equal to the array shape.

### Varia

Apologies for this! 