### PR TITLE
let user retrieve the location of the dip

### DIFF
--- a/src/diptest-core/include/diptest/diptest.hpp
+++ b/src/diptest-core/include/diptest/diptest.hpp
@@ -353,6 +353,7 @@ double diptst(
     const double x[],
     const int_vt n,
     int_vt* lo_hi,
+    int_vt* dipidx,
     int_vt* gcm,
     int_vt* lcm,
     int_vt* mn,
@@ -381,6 +382,7 @@ double diptst(
      *  Parameter adjustments, so that array referencing starts at 1,
      *  i.e., x[1]..x[n]
      */
+    --dipidx;
     --mj;
     --mn;
     --lcm;
@@ -570,6 +572,7 @@ L_END:
 #endif
     lo_hi[2] = l_gcm;
     lo_hi[3] = l_lcm;
+    *(dipidx + 1) = tmp_dip.idx;
     return dip;
 }  // diptst
 #undef low

--- a/src/diptest-core/include/diptest/diptest.hpp
+++ b/src/diptest-core/include/diptest/diptest.hpp
@@ -335,6 +335,7 @@ inline double max_distance(
  * @param[in] n the size of the array
  * @param[out] lo_hi an array of size 4 that is used to return the lower and the
  * upper end of the model interval, and the relative lengths of gcm and lcm
+ * @param[out] dipidx index of the dip
  * @param[out] ifault an error integer. A value of 1 indicates that n is non-
  * positive. A value of 2 indicates that the array x was not sorted
  * @param gcm[out] the greatest convex minorant

--- a/src/diptest-core/src/bootstrap.cpp
+++ b/src/diptest-core/src/bootstrap.cpp
@@ -33,6 +33,7 @@ double diptest_pval(
     std::uniform_real_distribution<double> dist(0.0, 1.0);
 
     std::array<int_vt, 4> lo_hi = {0, 0, 0, 0};
+    std::unique_ptr<int_vt[]> dipidx(new int_vt[1]);
     std::unique_ptr<int_vt[]> gcm(new int_vt[n]);
     std::unique_ptr<int_vt[]> lcm(new int_vt[n]);
     std::unique_ptr<int_vt[]> mn(new int_vt[n]);
@@ -52,6 +53,7 @@ double diptest_pval(
             r_sample,
             n,
             lo_hi.data(),
+            dipidx.get(),
             gcm.get(),
             lcm.get(),
             mn.get(),
@@ -92,6 +94,7 @@ double diptest_pval_mt(
     {
         std::unique_ptr<int_vt[]> lo_hi(new int_vt[n]);
         std::memset(lo_hi.get(), 0, 4);
+        std::unique_ptr<int_vt[]> dipidx(new int_vt[1]);
         std::unique_ptr<int_vt[]> gcm(new int_vt[n]);
         std::unique_ptr<int_vt[]> lcm(new int_vt[n]);
         std::unique_ptr<int_vt[]> mn(new int_vt[n]);
@@ -121,6 +124,7 @@ double diptest_pval_mt(
                           p_sample,
                           n,
                           lo_hi.get(),
+                          dipidx.get(),
                           gcm.get(),
                           lcm.get(),
                           mn.get(),

--- a/src/diptest-core/src/dipstat.cpp
+++ b/src/diptest-core/src/dipstat.cpp
@@ -12,6 +12,7 @@ inline double diptest(
     const double* x_ptr, int_vt N, int allow_zero, int debug
 ) {
     std::array<int_vt, 4> lo_hi = {0, 0, 0, 0};
+    std::unique_ptr<int_vt[]> dipidx(new int_vt[N]);
     std::unique_ptr<int_vt[]> gcm(new int_vt[N]);
     std::unique_ptr<int_vt[]> lcm(new int_vt[N]);
     std::unique_ptr<int_vt[]> mn(new int_vt[N]);
@@ -21,6 +22,7 @@ inline double diptest(
         x_ptr,
         N,
         lo_hi.data(),
+        dipidx.get(),
         gcm.get(),
         lcm.get(),
         mn.get(),
@@ -46,6 +48,8 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
     auto lcm = py::array_t<int_vt>(N);
     int_vt* gcm_ptr = gcm.mutable_data();
     int_vt* lcm_ptr = lcm.mutable_data();
+    auto dipidx = py::array_t<int_vt>(1);
+    int_vt* dipidx_ptr = dipidx.mutable_data();
 
     std::unique_ptr<int_vt[]> mn(new int_vt[N]);
     std::unique_ptr<int_vt[]> mj(new int_vt[N]);
@@ -56,6 +60,7 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
         x_ptr,
         N,
         lo_hi.data(),
+        dipidx_ptr,
         gcm_ptr,
         lcm_ptr,
         mn_ptr,
@@ -73,6 +78,7 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
         "dip"_a = dip,
         "lo"_a = lo,
         "hi"_a = hi,
+        "dipidx"_a = dipidx.at(0) - 1,
         "xl"_a = x.at(lo),
         "xu"_a = x.at(hi),
         "_gcm"_a = gcm,

--- a/src/diptest/diptest.py
+++ b/src/diptest/diptest.py
@@ -58,6 +58,7 @@ def dipstat(
             xu:     upper end of modal interval
             gcm:    (last-used) indices of the greatest concave majorant
             lcm:    (last-used) indices of the least concave majorant
+            dipidx: index of the dip
 
     Reference
     -----------
@@ -153,6 +154,7 @@ def diptest(
             xu:     upper end of modal interval
             gcm:    (last-used) indices of the greatest concave majorant
             lcm:    (last-used) indices of the least concave majorant
+            dipidx: index of the dip
 
     Reference:
     -----------


### PR DESCRIPTION
A shot at https://github.com/RUrlus/diptest/issues/76

There are a few issues with the PR:

* no tests
* only very brief doc in the python and C++ function for the new parameter
* data type is weird, it should be a single number -- it's been a while since I used C++; I copied the code from other objects, which use arrays, so this is a 1-element array.
* potentially off by one bug, one in the --dipidx and one in the subtracting one at the end.

Would be cool to have this feature supported in diptest though!