### PR TITLE
FEAT: Add dip index/location to full output

### DIFF
--- a/src/diptest-core/include/diptest/bootstrap.hpp
+++ b/src/diptest-core/include/diptest/bootstrap.hpp
@@ -10,12 +10,7 @@
 #include <omp.h>
 #endif
 
-#include <algorithm>  // sort
-#include <cmath>      // NAN
-#include <memory>     // unique_ptr
-#include <numeric>    // accumulate
-#include <random>     // uniform_real_distribution
-#include <stdexcept>  // runtime_error
+#include <memory>  // unique_ptr
 
 #include <diptest/arena.hpp>
 #include <diptest/common.hpp>

--- a/src/diptest-core/include/diptest/diptest.hpp
+++ b/src/diptest-core/include/diptest/diptest.hpp
@@ -335,7 +335,6 @@ inline double max_distance(
  * @param[in] n the size of the array
  * @param[out] lo_hi an array of size 4 that is used to return the lower and the
  * upper end of the model interval, and the relative lengths of gcm and lcm
- * @param[out] dipidx index of the dip
  * @param[out] ifault an error integer. A value of 1 indicates that n is non-
  * positive. A value of 2 indicates that the array x was not sorted
  * @param gcm[out] the greatest convex minorant
@@ -354,7 +353,6 @@ double diptst(
     const double x[],
     const int_vt n,
     int_vt* lo_hi,
-    int_vt* dipidx,
     int_vt* gcm,
     int_vt* lcm,
     int_vt* mn,
@@ -383,7 +381,6 @@ double diptst(
      *  Parameter adjustments, so that array referencing starts at 1,
      *  i.e., x[1]..x[n]
      */
-    --dipidx;
     --mj;
     --mn;
     --lcm;
@@ -392,6 +389,8 @@ double diptst(
 
     ConvexEnvelope gcm_obj(x, gcm, mn, n, MINORANT);
     ConvexEnvelope lcm_obj(x, lcm, mj, n, MAJORANT);
+
+    int_vt dip_idx = -1;
 
     // Perform the two consistency checks:
 
@@ -540,6 +539,7 @@ double diptst(
         }
         if (dip < tmp_dip.val) {
             dip = tmp_dip.val;
+            dip_idx = tmp_dip.idx;
 #if defined(DIPTEST_DEBUG)
             if (debug)
                 cout << " --> new larger dip " << (tmp_dip.val)
@@ -564,16 +564,15 @@ L_END:
      * M. Maechler -- speedup: Work with (2n * dip) everywhere but the very end!
      * It saves many divisions by n!
      */
-    // cast n to 64bit in case it overflows in the multiplication
-    // TODO(ru)  add settable index size
 #ifdef DIPTEST_64BIT_INDEX
     dip /= static_cast<double>(2 * n);
 #else
+    // cast n to 64bit in case it overflows in the multiplication
     dip /= static_cast<double>(2 * static_cast<int64_t>(n));
 #endif
     lo_hi[2] = l_gcm;
     lo_hi[3] = l_lcm;
-    *(dipidx + 1) = tmp_dip.idx;
+    lo_hi[4] = dip_idx;
     return dip;
 }  // diptst
 #undef low

--- a/src/diptest-core/include/diptest/diptest.hpp
+++ b/src/diptest-core/include/diptest/diptest.hpp
@@ -302,8 +302,8 @@ inline double max_distance(
             lcm.x = lcm.y - is_maj;
 #if defined(DIPTEST_DEBUG)
             if (debug >= 2) {
-                cout << ((is_maj) ? "G" : "L") << "(" << (gcm.x) << ", "
-                     << (lcm.x) << ")";
+                std::cout << ((is_maj) ? "G" : "L") << "(" << (gcm.x) << ", "
+                          << (lcm.x) << ")";
             }
 #endif  // DIPTEST_DEBUG
         }
@@ -315,10 +315,10 @@ inline double max_distance(
 #if defined(DIPTEST_DEBUG)
         if (debug) {
             if (debug >= 2) {
-                cout << " --> (gcm.y, lcm.y) = (" << (gcm.y) << ", " << (lcm.y)
-                     << ")" << endl;
+                std::cout << " --> (gcm.y, lcm.y) = (" << (gcm.y) << ", "
+                          << (lcm.y) << ")" << std::endl;
             } else {
-                cout << ".";
+                std::cout << ".";
             }
         }
 #endif  // DIPTEST_DEBUG
@@ -376,7 +376,6 @@ double diptst(
     Dip dip_l(min_is_0), dip_u(min_is_0), tmp_dip(min_is_0);
     int_vt i;
     bool flag;
-
     /**
      *  Parameter adjustments, so that array referencing starts at 1,
      *  i.e., x[1]..x[n]
@@ -415,8 +414,8 @@ double diptst(
 
 #if defined(DIPTEST_DEBUG)
     if (debug)
-        cout << "'dip': START: (N = " << n << ")"
-             << " and 2N*dip = " << dip << "." << endl;
+        std::cout << "'dip': START: (N = " << n << ")"
+                  << " and 2N*dip = " << dip << "." << std::endl;
 #endif  // DIPTEST_DEBUG
 
     /**
@@ -456,23 +455,23 @@ double diptst(
 
 #if defined(DIPTEST_DEBUG)
         if (debug) {
-            cout << "'dip': LOOP-BEGIN: 2n*D = " << dip
-                 << " and [low, high] = [" << setw(3) << low << ", " << setw(3)
-                 << high << "]";
+            std::cout << "'dip': LOOP-BEGIN: 2n*D = " << dip
+                      << " and [low, high] = [" << std::setw(3) << low << ", "
+                      << std::setw(3) << high << "]";
             if (debug >= 3) {
                 // Print the GCM:
-                cout << " :" << endl << " gcm[1:" << l_gcm << "] = ";
+                std::cout << " :" << std::endl << " gcm[1:" << l_gcm << "] = ";
                 for (i = 1; i < l_gcm; i++)
-                    cout << gcm[i] << ", ";
-                cout << gcm[l_gcm] << endl;
+                    std::cout << gcm[i] << ", ";
+                std::cout << gcm[l_gcm] << std::endl;
                 // Print the LCM:
-                cout << " lcm[1:" << l_lcm << "] = ";
+                std::cout << " lcm[1:" << l_lcm << "] = ";
                 for (i = 1; i < l_lcm; i++)
-                    cout << lcm[i] << ", ";
-                cout << lcm[l_lcm] << endl;
+                    std::cout << lcm[i] << ", ";
+                std::cout << lcm[l_lcm] << std::endl;
             } else {  // debug <= 2
-                cout << "; (l_lcm, l_gcm) = (" << setw(2) << l_lcm << ", "
-                     << setw(2) << l_gcm << ")" << endl;
+                std::cout << "; (l_lcm, l_gcm) = (" << std::setw(2) << l_lcm
+                          << ", " << std::setw(2) << l_gcm << ")" << std::endl;
             }
         }
 #endif  // DIPTEST_DEBUG
@@ -483,12 +482,12 @@ double diptst(
         if (l_gcm != 2 || l_lcm != 2) {
 #if defined(DIPTEST_DEBUG)
             if (debug) {
-                cout << "'dip': CYCLE-BEGIN: while(gcm[gcm_obj.y] "
-                     << "!= lcm[lcm_obj.y])";
+                std::cout << "'dip': CYCLE-BEGIN: while(gcm[gcm_obj.y] "
+                          << "!= lcm[lcm_obj.y])";
                 if (debug >= 2) {
-                    cout << endl;
+                    std::cout << std::endl;
                 } else {
-                    cout << " ";
+                    std::cout << " ";
                 }
             }
 #endif  // DIPTEST_DEBUG
@@ -496,17 +495,18 @@ double diptst(
             d = max_distance(gcm_obj, lcm_obj, debug);
 
 #if defined(DIPTEST_DEBUG)
-            if (debug && debug < 2)
-                cout << endl;
+            if (debug) {
+                std::cout << "'dip': distance " << d << std::endl;
+            }
 #endif  // DIPTEST_DEBUG
         } else {
             d = (min_is_0) ? 0. : 1.;
 
 #if defined(DIPTEST_DEBUG)
             if (debug)
-                cout << "'dip': NO-CYCLE: (l_lcm, l_gcm) = (" << setw(2)
-                     << l_lcm << ", " << setw(2) << l_gcm << ") ==> d := " << d
-                     << endl;
+                std::cout << "'dip': NO-CYCLE: (l_lcm, l_gcm) = ("
+                          << std::setw(2) << l_lcm << ", " << std::setw(2)
+                          << l_gcm << ") ==> d := " << d << std::endl;
 #endif  // DIPTEST_DEBUG
         }
 
@@ -516,7 +516,7 @@ double diptst(
         // Calculate the DIPs for the current LOW and HIGH
 #if defined(DIPTEST_DEBUG)
         if (debug)
-            cout << "'dip': MAIN-CALCULATION" << endl;
+            std::cout << "'dip': MAIN-CALCULATION" << std::endl;
 #endif  // DIPTEST_DEBUG
 
         // The DIP for the convex minorant.
@@ -527,8 +527,8 @@ double diptst(
 
 #if defined(DIPTEST_DEBUG)
         if (debug)
-            cout << " (dip_l, dip_u) = (" << dip_l.val << ", " << dip_u.val
-                 << ")";
+            std::cout << " (dip_l, dip_u) = (" << dip_l.val << ", " << dip_u.val
+                      << ")";
 #endif  // DIPTEST_DEBUG
 
         // Determine the current maximum.
@@ -542,8 +542,9 @@ double diptst(
             dip_idx = tmp_dip.idx;
 #if defined(DIPTEST_DEBUG)
             if (debug)
-                cout << " --> new larger dip " << (tmp_dip.val)
-                     << " ( at index := " << (tmp_dip.idx) << " )" << endl;
+                std::cout << " --> new larger dip " << (tmp_dip.val)
+                          << " ( at index := " << (tmp_dip.idx) << " )"
+                          << std::endl;
 #endif  // DIPTEST_DEBUG
         }
 
@@ -555,8 +556,8 @@ double diptst(
 
 #if defined(DIPTEST_DEBUG)
     if (debug)
-        cout << "'dip': LOOP-END: No improvement found neither in low := "
-             << low << " nor in high := " << high << endl;
+        std::cout << "'dip': LOOP-END: No improvement found neither in low := "
+                  << low << " nor in high := " << high << std::endl;
 #endif  // DIPTEST_DEBUG
 
 L_END:

--- a/src/diptest-core/include/diptest/diptest.hpp
+++ b/src/diptest-core/include/diptest/diptest.hpp
@@ -335,6 +335,7 @@ inline double max_distance(
  * @param[in] n the size of the array
  * @param[out] lo_hi an array of size 4 that is used to return the lower and the
  * upper end of the model interval, and the relative lengths of gcm and lcm
+ * @param[out] dipidx index of the dip
  * @param[out] ifault an error integer. A value of 1 indicates that n is non-
  * positive. A value of 2 indicates that the array x was not sorted
  * @param gcm[out] the greatest convex minorant
@@ -353,6 +354,7 @@ double diptst(
     const double x[],
     const int_vt n,
     int_vt* lo_hi,
+    int_vt* dipidx,
     int_vt* gcm,
     int_vt* lcm,
     int_vt* mn,
@@ -381,6 +383,7 @@ double diptst(
      *  Parameter adjustments, so that array referencing starts at 1,
      *  i.e., x[1]..x[n]
      */
+    --dipidx;
     --mj;
     --mn;
     --lcm;
@@ -570,6 +573,7 @@ L_END:
 #endif
     lo_hi[2] = l_gcm;
     lo_hi[3] = l_lcm;
+    *(dipidx + 1) = tmp_dip.idx;
     return dip;
 }  // diptst
 #undef low

--- a/src/diptest-core/src/bootstrap.cpp
+++ b/src/diptest-core/src/bootstrap.cpp
@@ -1,10 +1,10 @@
 /* wrapper.cpp -- implementation of wrapper around diptst from diptest.c
  * Copyright 2022 R. Urlus
  */
-#include <functional>
+#include <algorithm>  // sort
 #include <memory>
-#include <queue>
-#include <vector>
+#include <numeric>  // accumulate
+#include <random>   // uniform_real_distribution
 
 #include <diptest/bootstrap.hpp>
 
@@ -32,8 +32,7 @@ double diptest_pval(
     }
     std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-    std::array<int_vt, 4> lo_hi = {0, 0, 0, 0};
-    std::unique_ptr<int_vt[]> dipidx(new int_vt[1]);
+    std::array<int_vt, 5> lo_hi = {0, 0, 0, 0, 0};
     std::unique_ptr<int_vt[]> gcm(new int_vt[n]);
     std::unique_ptr<int_vt[]> lcm(new int_vt[n]);
     std::unique_ptr<int_vt[]> mn(new int_vt[n]);
@@ -53,7 +52,6 @@ double diptest_pval(
             r_sample,
             n,
             lo_hi.data(),
-            dipidx.get(),
             gcm.get(),
             lcm.get(),
             mn.get(),
@@ -92,9 +90,7 @@ double diptest_pval_mt(
 
 #pragma omp parallel num_threads(n_threads) shared(dips, global_rng)
     {
-        std::unique_ptr<int_vt[]> lo_hi(new int_vt[n]);
-        std::memset(lo_hi.get(), 0, 4);
-        std::unique_ptr<int_vt[]> dipidx(new int_vt[1]);
+        std::array<int_vt, 5> lo_hi = {0, 0, 0, 0, 0};
         std::unique_ptr<int_vt[]> gcm(new int_vt[n]);
         std::unique_ptr<int_vt[]> lcm(new int_vt[n]);
         std::unique_ptr<int_vt[]> mn(new int_vt[n]);
@@ -123,8 +119,7 @@ double diptest_pval_mt(
             dips[i] = dipstat <= diptst<false>(
                           p_sample,
                           n,
-                          lo_hi.get(),
-                          dipidx.get(),
+                          lo_hi.data(),
                           gcm.get(),
                           lcm.get(),
                           mn.get(),

--- a/src/diptest-core/src/bootstrap.cpp
+++ b/src/diptest-core/src/bootstrap.cpp
@@ -33,6 +33,7 @@ double diptest_pval(
     std::uniform_real_distribution<double> dist(0.0, 1.0);
 
     std::array<int_vt, 4> lo_hi = {0, 0, 0, 0};
+    std::unique_ptr<int_vt[]> dipidx(new int_vt[1]);
     std::unique_ptr<int_vt[]> gcm(new int_vt[n]);
     std::unique_ptr<int_vt[]> lcm(new int_vt[n]);
     std::unique_ptr<int_vt[]> mn(new int_vt[n]);
@@ -52,6 +53,7 @@ double diptest_pval(
             r_sample,
             n,
             lo_hi.data(),
+            dipidx.get(),
             gcm.get(),
             lcm.get(),
             mn.get(),
@@ -92,6 +94,7 @@ double diptest_pval_mt(
     {
         std::unique_ptr<int_vt[]> lo_hi(new int_vt[n]);
         std::memset(lo_hi.get(), 0, 4);
+        std::unique_ptr<int_vt[]> dipidx(new int_vt[1]);
         std::unique_ptr<int_vt[]> gcm(new int_vt[n]);
         std::unique_ptr<int_vt[]> lcm(new int_vt[n]);
         std::unique_ptr<int_vt[]> mn(new int_vt[n]);
@@ -121,6 +124,7 @@ double diptest_pval_mt(
                           p_sample,
                           n,
                           lo_hi.get(),
+                          dipidx.get(),
                           gcm.get(),
                           lcm.get(),
                           mn.get(),

--- a/src/diptest-core/src/dipstat.cpp
+++ b/src/diptest-core/src/dipstat.cpp
@@ -12,6 +12,7 @@ inline double diptest(
     const double* x_ptr, int_vt N, int allow_zero, int debug
 ) {
     std::array<int_vt, 4> lo_hi = {0, 0, 0, 0};
+    std::unique_ptr<int_vt[]> dipidx(new int_vt[N]);
     std::unique_ptr<int_vt[]> gcm(new int_vt[N]);
     std::unique_ptr<int_vt[]> lcm(new int_vt[N]);
     std::unique_ptr<int_vt[]> mn(new int_vt[N]);
@@ -21,6 +22,7 @@ inline double diptest(
         x_ptr,
         N,
         lo_hi.data(),
+        dipidx.get(),
         gcm.get(),
         lcm.get(),
         mn.get(),
@@ -46,6 +48,8 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
     auto lcm = py::array_t<int_vt>(N);
     int_vt* gcm_ptr = gcm.mutable_data();
     int_vt* lcm_ptr = lcm.mutable_data();
+    auto dipidx = py::array_t<int_vt>(1);
+    int_vt* dipidx_ptr = dipidx.mutable_data();
 
     std::unique_ptr<int_vt[]> mn(new int_vt[N]);
     std::unique_ptr<int_vt[]> mj(new int_vt[N]);
@@ -56,6 +60,7 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
         x_ptr,
         N,
         lo_hi.data(),
+        dipidx_ptr,
         gcm_ptr,
         lcm_ptr,
         mn_ptr,
@@ -73,6 +78,7 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
         "dip"_a = dip,
         "lo"_a = lo,
         "hi"_a = hi,
+        "dipidx"_a = dipidx.at(0) - 1,
         "xl"_a = x.at(lo),
         "xu"_a = x.at(hi),
         "_gcm"_a = gcm,

--- a/src/diptest-core/src/dipstat.cpp
+++ b/src/diptest-core/src/dipstat.cpp
@@ -11,8 +11,7 @@ namespace details {
 inline double diptest(
     const double* x_ptr, int_vt N, int allow_zero, int debug
 ) {
-    std::array<int_vt, 4> lo_hi = {0, 0, 0, 0};
-    std::unique_ptr<int_vt[]> dipidx(new int_vt[N]);
+    std::array<int_vt, 5> lo_hi = {0, 0, 0, 0, 0};
     std::unique_ptr<int_vt[]> gcm(new int_vt[N]);
     std::unique_ptr<int_vt[]> lcm(new int_vt[N]);
     std::unique_ptr<int_vt[]> mn(new int_vt[N]);
@@ -22,7 +21,6 @@ inline double diptest(
         x_ptr,
         N,
         lo_hi.data(),
-        dipidx.get(),
         gcm.get(),
         lcm.get(),
         mn.get(),
@@ -42,14 +40,12 @@ double diptest(const py::array_t<double>& x, int allow_zero, int debug) {
 py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
     const double* x_ptr = x.data();
     int_vt N = x.size();
-    std::array<int_vt, 4> lo_hi = {0, 0, 0, 0};
+    std::array<int_vt, 5> lo_hi = {0, 0, 0, 0, 0};
 
     auto gcm = py::array_t<int_vt>(N);
     auto lcm = py::array_t<int_vt>(N);
     int_vt* gcm_ptr = gcm.mutable_data();
     int_vt* lcm_ptr = lcm.mutable_data();
-    auto dipidx = py::array_t<int_vt>(1);
-    int_vt* dipidx_ptr = dipidx.mutable_data();
 
     std::unique_ptr<int_vt[]> mn(new int_vt[N]);
     std::unique_ptr<int_vt[]> mj(new int_vt[N]);
@@ -60,7 +56,6 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
         x_ptr,
         N,
         lo_hi.data(),
-        dipidx_ptr,
         gcm_ptr,
         lcm_ptr,
         mn_ptr,
@@ -78,7 +73,7 @@ py::dict diptest_full(const py::array_t<double>& x, int allow_zero, int debug) {
         "dip"_a = dip,
         "lo"_a = lo,
         "hi"_a = hi,
-        "dipidx"_a = dipidx.at(0) - 1,
+        "dipidx"_a = lo_hi[4] - 1,
         "xl"_a = x.at(lo),
         "xu"_a = x.at(hi),
         "_gcm"_a = gcm,

--- a/src/diptest/diptest.py
+++ b/src/diptest/diptest.py
@@ -58,6 +58,7 @@ def dipstat(
             xu:     upper end of modal interval
             gcm:    (last-used) indices of the greatest concave majorant
             lcm:    (last-used) indices of the least concave majorant
+            dipidx: index of the dip
 
     Reference
     -----------
@@ -153,6 +154,7 @@ def diptest(
             xu:     upper end of modal interval
             gcm:    (last-used) indices of the greatest concave majorant
             lcm:    (last-used) indices of the least concave majorant
+            dipidx: index of the dip
 
     Reference:
     -----------

--- a/tests/test_diptest.py
+++ b/tests/test_diptest.py
@@ -107,7 +107,7 @@ def test_dipstat_full_output():
     """Test diptest.dipstat with full output."""
     sample = _generator(100)
     dip, res = dt.dipstat(sample, full_output=True)
-    exp_keys = {"lo", "hi", "xl", "xu", "gcm", "lcm"}
+    exp_keys = {"lo", "hi", "xl", "xu", "gcm", "lcm", "dipidx"}
     obs_keys = set(res.keys())
     assert len(obs_keys - exp_keys) == 0
     assert len(exp_keys - obs_keys) == 0
@@ -215,7 +215,6 @@ def test_diptest_full_output():
     dip, pval, res = dt.diptest(_TEST_SAMPLE, full_output=True)
     assert np.isclose(dip, _TEST_SAMPLE_DIP)
     assert np.isclose(pval, _TEST_SAMPLE_TABLE_PVAL)
-    exp_keys = {"lo", "hi", "xl", "xu", "gcm", "lcm"}
+    exp_keys = {"lo", "hi", "xl", "xu", "gcm", "lcm", "dipidx"}
     obs_keys = set(res.keys())
     assert len(obs_keys - exp_keys) == 0
-    assert len(exp_keys - obs_keys) == 0


### PR DESCRIPTION
Continues on with the dip location feature from #77.

closes #76